### PR TITLE
Fix run method accessibility

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -16,7 +16,7 @@ class Component extends BaseComponent
     /**
      * @throws \Keboola\Component\UserException
      */
-    public function run(): void
+    protected function run(): void
     {
         /** @var Config $config */
         $config = $this->getConfig();

--- a/src/run.php
+++ b/src/run.php
@@ -11,7 +11,7 @@ require __DIR__ . '/../vendor/autoload.php';
 $logger = new Logger();
 try {
     $app = new Component($logger);
-    $app->run();
+    $app->execute();
     exit(0);
 } catch (UserException $e) {
     $logger->error($e->getMessage());


### PR DESCRIPTION
Method "run" cannot be public since version 7

https://app.datadoghq.eu/logs?query=%40exceptionId%3A%2Aexception-156164158e2f98024cc07cee0990d5fa%2A%20&cols=host%2Cservice%2Ccomponent&event=AgAAAY3WWDbVZ1SQIQAAAAAAAAAYAAAAAEFZM1dXRWVZQUFCOURzdThpaGFxS0FBQwAAACQAAAAAMDE4ZGQ2NTgtNzQwOC00MzYyLWIwMTAtN2YxYzRjYWJhNTg2&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&saved-view-id=56416&stream_sort=desc&viz=stream&from_ts=1708683798290&to_ts=1708698198290&live=true